### PR TITLE
Some fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,10 +179,26 @@
 
       refreshCanvas();
 
-      canvas.toBlob((blob) => {
-        const url = URL.createObjectURL(blob);
-        document.getElementById('downloadLink').href = url;
-      }, 'image/png');
+      function slugify(text) {
+        return text.toString().toLowerCase().trim()
+          .normalize('NFD') 				       // separate accent from letter
+          .replace(/[\u0300-\u036f]/g, '') // remove all separated accents
+          .replace(/\s+/g, '-')            // replace spaces with -
+          .replace(/&/g, '-and-')          // replace & with 'and'
+          .replace(/[^\w\-]+/g, '')        // remove all non-word chars
+          .replace(/\-\-+/g, '-')          // replace multiple '-' with single '-'
+      }
+
+      document.getElementById('downloadLink').addEventListener('click', (evt) => {
+        canvas.toBlob((blob) => {
+          const a = document.createElement('a');
+          a.href = URL.createObjectURL(blob);
+          a.download = `${slugify(imgParams.text)}.png`;
+          a.click();
+
+          URL.revokeObjectURL(a.href);
+        }, 'image/png');
+      });
 
       document.getElementById('base64exporter').addEventListener('submit', (evt) => {
         evt.preventDefault();
@@ -250,7 +266,7 @@
 
   <div id="actions">
     <div><a id="copyUrl" href="javascript:void(0);">Copy current state as URL</a></div>
-    <div><a id="downloadLink" href="#" download="category.png">Download</a></div>
+    <div><a id="downloadLink" href="javascript:void(0);">Download</a></div>
     <div><a href="javascript:void(0);" onclick="document.getElementById('base64exporter').classList.toggle('hidden')">Copy as base64</a></div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -20,6 +20,19 @@
     input[type=color] {
       width: 100%;
     }
+    #base64exporter {
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      max-width: 300px;
+      grid-gap: 0.5em;
+      margin-bottom: 20px;
+      border: 1px solid #686868;
+      padding: 5px;
+      border-radius: 3px;
+    }
+    #base64exporter.hidden {
+      display: none;
+    }
   </style>
 
   <script type="text/javascript">
@@ -171,11 +184,14 @@
         document.getElementById('downloadLink').href = url;
       }, 'image/png');
 
-      document.getElementById('copyPngDataUrl').addEventListener('click', () => {
-        navigator.clipboard.writeText(canvas.toDataURL('image/png'));
-      });
-      document.getElementById('copyJpegDataUrl').addEventListener('click', () => {
-        navigator.clipboard.writeText(canvas.toDataURL('image/jpeg'));
+      document.getElementById('base64exporter').addEventListener('submit', (evt) => {
+        evt.preventDefault();
+        const format = evt?.target?.elements?.format?.value;
+        const quality = Number.parseFloat(evt?.target?.elements?.quality?.value);
+
+        navigator.clipboard.writeText(canvas.toDataURL(`image/${format}`, quality));
+
+        return false;
       });
 
       document.getElementById('copyUrl').addEventListener('click', () => {
@@ -233,11 +249,23 @@
   <div id="canvasInputs"></div>
 
   <div id="actions">
-    <div><a id="downloadLink" href="#" download="category.png">Download</a></div>
-    <div><a id="copyPngDataUrl" href="javascript:void(0);">Copy as base64 PNG</a></div>
-    <div><a id="copyJpegDataUrl" href="javascript:void(0);">Copy as base64 JPEG</a></div>
     <div><a id="copyUrl" href="javascript:void(0);">Copy current state as URL</a></div>
+    <div><a id="downloadLink" href="#" download="category.png">Download</a></div>
+    <div><a href="javascript:void(0);" onclick="document.getElementById('base64exporter').classList.toggle('hidden')">Copy as base64</a></div>
   </div>
+
+  <form id="base64exporter" class="hidden">
+    <div>Format</div>
+    <div>Quality</div>
+    <div></div>
+
+    <select name="format">
+      <option value="png">PNG</option>
+      <option value="jpeg">JPEG</option>
+    </select>
+    <input name="quality" type="range" step="0.1" min="0" max="1" value="1" />
+    <button type="submit">Copy</button>
+  </form>
 
   <canvas id="canvas" width="200" height="400"></canvas>
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 
       const imgParams = {
         bgcolor: params.bgcolor || '#e74c3c',
-        txtcolor: params.txtcolor || '#fff',
+        txtcolor: params.txtcolor || '#ffffff',
         ftsize: params.ftsize || 35,
         ftweight: params.ftweight || 'bolder',
         ftfamily: params.ftfamily || 'Arial',


### PR DESCRIPTION
- Use long HEX format as default text color (prevents the color input from going black instead of white)
- Add a base64 export form so that the user can choose export quality (useful for JPEG)
- Use a slug of the text as filename when downloading the image
- Generate the image on the fly when downloading